### PR TITLE
systemd unit: Fix circular dependency

### DIFF
--- a/data/lmkd.service
+++ b/data/lmkd.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Low Memory Killer Daemon
-After=multi-user.target
-Wants=multi-user.target
 
 [Service]
 Type=simple

--- a/data/lmkd.service
+++ b/data/lmkd.service
@@ -8,9 +8,6 @@ Restart=always
 RestartSec=1
 User=root
 Group=root
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=lmkd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This fixes a dependency in data/lmkd.service that leads to systemd shutting down graphical.target when lkmd.service is started. This e.g. causes phosh to be killed when lmkd is installed and activated on the FLX1.